### PR TITLE
[WIP] Make more diagnostics accessible via the PyFBU class

### DIFF
--- a/fbu/PyFBU.py
+++ b/fbu/PyFBU.py
@@ -158,7 +158,8 @@ class PyFBU(object):
             init_time = time.time()
 
             if self.mode:
-                map_estimate = mc.find_MAP(model=model, method=self.MAP_method)
+                map_estimate = mc.find_MAP(model=model, method=self.MAP_method,
+                                           options={'disp':self.verbose})
                 print (map_estimate)
                 self.MAP = map_estimate
                 self.trace = []

--- a/fbu/PyFBU.py
+++ b/fbu/PyFBU.py
@@ -22,6 +22,7 @@ class PyFBU(object):
         self.nCores = 1 # number of CPU threads to utilize
         self.nChains = 2 # number of Markov chains to sample
         self.nuts_kwargs = None
+        self.init_method = 'jitter+adapt_diag'
         self.discard_tuned_samples = True # whether to discard tuning steps from posterior
         self.lower = lower  # lower sampling bounds
         self.upper = upper  # upper sampling bounds
@@ -156,9 +157,6 @@ class PyFBU(object):
             from datetime import timedelta
             init_time = time.time()
 
-            print(self.nuts_kwargs)
-
-            
             if self.mode:
                 map_estimate = mc.find_MAP(model=model, method=self.MAP_method)
                 print (map_estimate)
@@ -169,6 +167,7 @@ class PyFBU(object):
 
             trace = mc.sample(self.nMCMC,tune=self.nTune,cores=self.nCores,
                               chains=self.nChains, nuts_kwargs=self.nuts_kwargs,
+                              init=self.init_method, n_init=200000,
                               discard_tuned_samples=self.discard_tuned_samples,
                               progressbar=self.sampling_progressbar)
             finish_time = time.time()

--- a/fbu/PyFBU.py
+++ b/fbu/PyFBU.py
@@ -178,7 +178,8 @@ class PyFBU(object):
             ))
 
             self.trace = [trace['truth%d'%bin][:] for bin in range(truthdim)]
-            #self.trace = [copy.deepcopy(trace['truth%d'%bin][:]) for bin in range(truthdim)]
+            self.__trace__ = trace # for full access
+            self.trace_summary = mc.summary(trace)
             self.nuisancestrace = {}
             if nbckg>0:
                 for name,err in zip(backgroundkeys,backgroundnormsysts):


### PR DESCRIPTION
This PR add a few extra configurable options and diagnostics:

- Ability to set sampler initialization method (the default value is with respect to NUTS sampler
- Printout maximum a posteriori minimization steps in verbose mode
- Access to full trace object from PyMC (not just the pre-formatted `trace` dictionary we already provide with subset of information) in `__trace__` variable
- Summary information in a pandas dataframe `trace_summary` from the PyMC summary method
