### PR TITLE
[WIP] Extra options for nuisance parameters and backgrounds treatment

### DIFF
--- a/fbu/PyFBU.py
+++ b/fbu/PyFBU.py
@@ -186,17 +186,14 @@ class PyFBU(object):
 
             if self.include_gammas and nbckg > 0:
                 gammas = [mc.Uniform('flat_gamma_{0}'.format(i), lower=0.,
-                                     upper=10.) for i in range(self.nbins)]
+                                     upper=2.) for i in range(self.nbins)]
                 gammas = mc.math.stack(gammas)
 
                 # construct the Poisson constraint on gammas
                 tau = (totalbckg/totalbckg_err)**2
-                m = reciprocal(tau)
-                print(sqrt(m))
-                print(reciprocal(sqrt(totalbckg)))
                 gamma_poissons = [
                     mc.Poisson('poisson_gamma_{0}'.format(i),
-                               mu=tau[i], observed=m[i]) for i in range(self.nbins)]
+                               mu=gammas[i]*tau[i], observed=tau[i]) for i in range(self.nbins)]
 
         # define potential to constrain truth spectrum
             if self.regularization:


### PR DESCRIPTION
This PR is large, so apologies for convoluting so many changes in a single PR ... I realized they depend on each other too much hence why. But we can of course try to iterate on them one by one.

Several features we found useful in a specific measurement are introduced here:
- By default ,we assume that the nuisance parameters for object-related systematic uncertainties have gaussian priors. For certain diagnostic cases, it is usefull to replace these with flat prior, the `obj_syst_flatprior` dictionary is added for this purpose, where every NP with a matching substring in the name is assigned a flat prior with configurable bounds. The design of this feature is pretty terrible from interface perspective, but unfortunately I find that anything more complex requires serious interface reworking, hence this preliminary support.
- Ability to fix NP to a certain value -- the motivation from my side is mostly the ability to estimate impact of NP on the result by fixing and varying it's value.
- Treatment of limited statistics available for the background estimate by introducing per-bin nuisance parameters with a Poisson constraint (somewhat similar to Beeston-Barlow approach). The implementation loosely follows that in the [HistFactory documentation](https://cds.cern.ch/record/1456844).